### PR TITLE
feat: registro y gestión de objetivos personales del atleta

### DIFF
--- a/backend/tests/test_goals.py
+++ b/backend/tests/test_goals.py
@@ -1,0 +1,196 @@
+import pytest
+from rest_framework.test import APIClient
+from users.models import User, AthleteProfile, Goal
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def athlete(db):
+    user = User.objects.create_user(
+        username="atleta1",
+        password="password123",
+        role="athlete",
+        email="atleta1@test.com",
+    )
+    AthleteProfile.objects.create(
+        user=user, height=170, age=25, gender="M", activity_level="medium"
+    )
+    return user
+
+
+@pytest.fixture
+def other_athlete(db):
+    user = User.objects.create_user(
+        username="atleta2",
+        password="password123",
+        role="athlete",
+        email="atleta2@test.com",
+    )
+    AthleteProfile.objects.create(
+        user=user, height=165, age=30, gender="F", activity_level="low"
+    )
+    return user
+
+
+@pytest.fixture
+def athlete_client(athlete):
+    client = APIClient()
+    client.force_authenticate(user=athlete)
+    return client
+
+
+@pytest.fixture
+def profile(athlete):
+    return AthleteProfile.objects.get(user=athlete)
+
+
+@pytest.fixture
+def other_profile(other_athlete):
+    return AthleteProfile.objects.get(user=other_athlete)
+
+
+# ── CA1: Registrar meta con todos los campos ──────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_athlete_can_create_goal_with_all_fields(athlete_client):
+    """Happy path: atleta crea una meta con fecha límite y valor objetivo."""
+    response = athlete_client.post(
+        "/api/athlete/goals/",
+        {
+            "goal_type": "lose_weight",
+            "description": "Bajar 5kg antes del verano",
+            "target_value": 70.0,
+            "current_value": 75.0,
+            "deadline": "2025-08-01",
+        },
+    )
+    assert response.status_code == 201
+    assert response.data["goal_type"] == "lose_weight"
+    assert response.data["target_value"] == 70.0
+    assert response.data["deadline"] == "2025-08-01"
+
+
+@pytest.mark.django_db
+def test_create_goal_without_goal_type_fails(athlete_client):
+    """Flujo alternativo: crear meta sin goal_type retorna 400."""
+    response = athlete_client.post(
+        "/api/athlete/goals/",
+        {
+            "target_value": 70.0,
+            "deadline": "2025-08-01",
+        },
+    )
+    assert response.status_code == 400
+
+
+# ── CA2: Listar metas ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_athlete_can_list_goals(athlete_client, profile):
+    """Happy path: atleta puede ver sus metas registradas."""
+    Goal.objects.create(athlete=profile, goal_type="gain_muscle", target_value=80.0)
+    Goal.objects.create(athlete=profile, goal_type="endurance")
+
+    response = athlete_client.get("/api/athlete/goals/")
+    assert response.status_code == 200
+    assert len(response.data) == 2
+
+
+@pytest.mark.django_db
+def test_athlete_with_no_goals_returns_empty_list(athlete_client):
+    """Flujo alternativo: atleta sin metas retorna lista vacía."""
+    response = athlete_client.get("/api/athlete/goals/")
+    assert response.status_code == 200
+    assert response.data == []
+
+
+# ── CA3: Ver detalle de una meta ──────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_athlete_can_get_goal_detail(athlete_client, profile):
+    """Happy path: atleta puede ver el detalle de una meta específica."""
+    goal = Goal.objects.create(
+        athlete=profile,
+        goal_type="lose_weight",
+        target_value=70.0,
+        deadline="2025-08-01",
+    )
+    response = athlete_client.get(f"/api/athlete/goals/{goal.id}/")
+    assert response.status_code == 200
+    assert response.data["goal_type"] == "lose_weight"
+
+
+@pytest.mark.django_db
+def test_get_nonexistent_goal_fails(athlete_client):
+    """Flujo alternativo: ver meta inexistente retorna 404."""
+    response = athlete_client.get("/api/athlete/goals/9999/")
+    assert response.status_code == 404
+
+
+# ── CA4: Editar una meta ──────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_athlete_can_edit_goal(athlete_client, profile):
+    """Happy path: atleta actualiza valor objetivo y fecha límite."""
+    goal = Goal.objects.create(
+        athlete=profile, goal_type="lose_weight", target_value=75.0
+    )
+    response = athlete_client.put(
+        f"/api/athlete/goals/{goal.id}/",
+        {
+            "goal_type": "lose_weight",
+            "target_value": 68.0,
+            "deadline": "2025-09-01",
+        },
+    )
+    assert response.status_code == 200
+    assert response.data["target_value"] == 68.0
+    assert response.data["deadline"] == "2025-09-01"
+
+
+@pytest.mark.django_db
+def test_athlete_cannot_edit_another_athletes_goal(athlete_client, other_profile):
+    """Flujo alternativo: atleta no puede editar metas de otro atleta."""
+    goal = Goal.objects.create(athlete=other_profile, goal_type="endurance")
+
+    response = athlete_client.put(
+        f"/api/athlete/goals/{goal.id}/",
+        {
+            "goal_type": "endurance",
+            "target_value": 10.0,
+        },
+    )
+    assert response.status_code == 404
+
+
+# ── CA5: Eliminar una meta ────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_athlete_can_delete_goal(athlete_client, profile):
+    """Happy path: atleta elimina una de sus metas."""
+    goal = Goal.objects.create(athlete=profile, goal_type="wellness")
+
+    response = athlete_client.delete(f"/api/athlete/goals/{goal.id}/")
+    assert response.status_code == 204
+
+
+@pytest.mark.django_db
+def test_delete_nonexistent_goal_fails(athlete_client):
+    """Flujo alternativo: eliminar meta inexistente retorna 404."""
+    response = athlete_client.delete("/api/athlete/goals/9999/")
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_athlete_cannot_delete_another_athletes_goal(athlete_client, other_profile):
+    """Flujo alternativo: atleta no puede eliminar metas de otro atleta."""
+    goal = Goal.objects.create(athlete=other_profile, goal_type="gain_muscle")
+
+    response = athlete_client.delete(f"/api/athlete/goals/{goal.id}/")
+    assert response.status_code == 404

--- a/backend/tests/test_goals.py
+++ b/backend/tests/test_goals.py
@@ -1,6 +1,7 @@
 import pytest
 from rest_framework.test import APIClient
-from users.models import User, AthleteProfile, Goal
+
+from users.models import AthleteProfile, Goal, User
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -27,9 +28,7 @@ def other_athlete(db):
         role="athlete",
         email="atleta2@test.com",
     )
-    AthleteProfile.objects.create(
-        user=user, height=165, age=30, gender="F", activity_level="low"
-    )
+    AthleteProfile.objects.create(user=user, height=165, age=30, gender="F", activity_level="low")
     return user
 
 
@@ -137,9 +136,7 @@ def test_get_nonexistent_goal_fails(athlete_client):
 @pytest.mark.django_db
 def test_athlete_can_edit_goal(athlete_client, profile):
     """Happy path: atleta actualiza valor objetivo y fecha límite."""
-    goal = Goal.objects.create(
-        athlete=profile, goal_type="lose_weight", target_value=75.0
-    )
+    goal = Goal.objects.create(athlete=profile, goal_type="lose_weight", target_value=75.0)
     response = athlete_client.put(
         f"/api/athlete/goals/{goal.id}/",
         {

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -11,6 +11,8 @@ from .views import (
     RegisterView,
     WeightLogView,
     protected_test,
+    GoalDetailView,
+    GoalLogView,
 )
 
 urlpatterns = [
@@ -21,7 +23,9 @@ urlpatterns = [
     path("api/users/profile/settings/", ProfileSettingsView, name="profile_settings"),
     # Coach - Athlete management
     path("api/users/athletes/search/", AthleteSearchView, name="athlete_search"),
-    path("api/users/coach/athletes/", CoachAthleteManagementView, name="coach_athletes"),
+    path(
+        "api/users/coach/athletes/", CoachAthleteManagementView, name="coach_athletes"
+    ),
     path(
         "api/users/coach/athletes/<int:athlete_id>/",
         CoachAthleteManagementView,
@@ -30,4 +34,6 @@ urlpatterns = [
     path("api/dashboard/athlete/", AthleteDashboardView, name="athlete_dashboard"),
     path("api/dashboard/coach/", CoachDashboardView, name="coach_dashboard"),
     path("api/athlete/weight-logs/", WeightLogView, name="weight_logs"),
+    path("api/athlete/goals/", GoalLogView, name="goals"),
+    path("api/athlete/goals/<int:goal_id>/", GoalDetailView, name="goal_detail"),
 ]

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -7,12 +7,12 @@ from .views import (
     CoachAthleteManagementView,
     CoachDashboardView,
     CustomTokenObtainPairView,
+    GoalDetailView,
+    GoalLogView,
     ProfileSettingsView,
     RegisterView,
     WeightLogView,
     protected_test,
-    GoalDetailView,
-    GoalLogView,
 )
 
 urlpatterns = [
@@ -23,9 +23,7 @@ urlpatterns = [
     path("api/users/profile/settings/", ProfileSettingsView, name="profile_settings"),
     # Coach - Athlete management
     path("api/users/athletes/search/", AthleteSearchView, name="athlete_search"),
-    path(
-        "api/users/coach/athletes/", CoachAthleteManagementView, name="coach_athletes"
-    ),
+    path("api/users/coach/athletes/", CoachAthleteManagementView, name="coach_athletes"),
     path(
         "api/users/coach/athletes/<int:athlete_id>/",
         CoachAthleteManagementView,

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -99,9 +99,7 @@ def AthleteSearchView(request):
 def CoachAthleteManagementView(request, athlete_id=None):
     """Gestiona la lista de atletas vinculados a un coach."""
     if request.user.role != "coach":
-        return Response(
-            {"detail": "Acceso denegado."}, status=status.HTTP_403_FORBIDDEN
-        )
+        return Response({"detail": "Acceso denegado."}, status=status.HTTP_403_FORBIDDEN)
 
     try:
         coach_profile = CoachProfile.objects.get(user=request.user)
@@ -126,16 +124,12 @@ def CoachAthleteManagementView(request, athlete_id=None):
                 {"detail": "Atleta vinculado correctamente."}, status=status.HTTP_200_OK
             )
         except User.DoesNotExist:
-            return Response(
-                {"detail": "Atleta no encontrado."}, status=status.HTTP_404_NOT_FOUND
-            )
+            return Response({"detail": "Atleta no encontrado."}, status=status.HTTP_404_NOT_FOUND)
 
     if request.method == "DELETE":
         # Desvincular atleta
         coach_profile.athletes.remove(athlete_id)
-        return Response(
-            {"detail": "Atleta desvinculado."}, status=status.HTTP_204_NO_CONTENT
-        )
+        return Response({"detail": "Atleta desvinculado."}, status=status.HTTP_204_NO_CONTENT)
 
 
 @api_view(["GET", "PATCH"])
@@ -163,9 +157,7 @@ def ProfileSettingsView(request):
                 if latest_weight:
                     profile_data["weight"] = latest_weight.weight
 
-                active_goal = (
-                    athlete.goals.filter(is_active=True).order_by("-id").first()
-                )
+                active_goal = athlete.goals.filter(is_active=True).order_by("-id").first()
                 if active_goal:
                     profile_data["training_goal"] = active_goal.goal_type
             except AthleteProfile.DoesNotExist:
@@ -246,9 +238,7 @@ def AthleteDashboardView(request):
     try:
         profile = AthleteProfile.objects.get(user=request.user)
     except AthleteProfile.DoesNotExist:
-        return Response(
-            {"detail": "Perfil no encontrado."}, status=status.HTTP_404_NOT_FOUND
-        )
+        return Response({"detail": "Perfil no encontrado."}, status=status.HTTP_404_NOT_FOUND)
 
     latest_weight = WeightLog.objects.filter(athlete=profile).order_by("-date").first()
     active_goal = Goal.objects.filter(athlete=profile, is_active=True).first()
@@ -259,9 +249,7 @@ def AthleteDashboardView(request):
             "age": profile.age,
             "gender": profile.gender,
             "activity_level": profile.activity_level,
-            "latest_weight": (
-                WeightLogSerializer(latest_weight).data if latest_weight else None
-            ),
+            "latest_weight": (WeightLogSerializer(latest_weight).data if latest_weight else None),
             "goal": GoalSerializer(active_goal).data if active_goal else None,
         }
     )
@@ -274,9 +262,7 @@ def WeightLogView(request):
     try:
         profile = AthleteProfile.objects.get(user=request.user)
     except AthleteProfile.DoesNotExist:
-        return Response(
-            {"detail": "Perfil no encontrado."}, status=status.HTTP_404_NOT_FOUND
-        )
+        return Response({"detail": "Perfil no encontrado."}, status=status.HTTP_404_NOT_FOUND)
 
     if request.method == "GET":
         logs = WeightLog.objects.filter(athlete=profile).order_by("-date")
@@ -298,9 +284,7 @@ def GoalLogView(request):
     try:
         profile = AthleteProfile.objects.get(user=request.user)
     except AthleteProfile.DoesNotExist:
-        return Response(
-            {"detail": "Perfil no encontrado."}, status=status.HTTP_404_NOT_FOUND
-        )
+        return Response({"detail": "Perfil no encontrado."}, status=status.HTTP_404_NOT_FOUND)
 
     if request.method == "GET":
         logs = Goal.objects.filter(athlete=profile).order_by("-start_date")
@@ -322,16 +306,12 @@ def GoalDetailView(request, goal_id):
     try:
         profile = AthleteProfile.objects.get(user=request.user)
     except AthleteProfile.DoesNotExist:
-        return Response(
-            {"detail": "Perfil no encontrado."}, status=status.HTTP_404_NOT_FOUND
-        )
+        return Response({"detail": "Perfil no encontrado."}, status=status.HTTP_404_NOT_FOUND)
 
     try:
         goal = Goal.objects.get(id=goal_id, athlete=profile)
     except Goal.DoesNotExist:
-        return Response(
-            {"detail": "Meta no encontrada."}, status=status.HTTP_404_NOT_FOUND
-        )
+        return Response({"detail": "Meta no encontrada."}, status=status.HTTP_404_NOT_FOUND)
 
     if request.method == "GET":
         return Response(GoalSerializer(goal).data)
@@ -356,16 +336,12 @@ def GoalDetailView(request, goal_id):
 def CoachDashboardView(request):
     """Devuelve los datos del dashboard del coach autenticado."""
     if request.user.role != "coach":
-        return Response(
-            {"detail": "Acceso denegado."}, status=status.HTTP_403_FORBIDDEN
-        )
+        return Response({"detail": "Acceso denegado."}, status=status.HTTP_403_FORBIDDEN)
 
     try:
         profile = CoachProfile.objects.get(user=request.user)
     except CoachProfile.DoesNotExist:
-        return Response(
-            {"detail": "Perfil no encontrado."}, status=status.HTTP_404_NOT_FOUND
-        )
+        return Response({"detail": "Perfil no encontrado."}, status=status.HTTP_404_NOT_FOUND)
 
     from routines.models import TrainingGroup
 

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -99,13 +99,16 @@ def AthleteSearchView(request):
 def CoachAthleteManagementView(request, athlete_id=None):
     """Gestiona la lista de atletas vinculados a un coach."""
     if request.user.role != "coach":
-        return Response({"detail": "Acceso denegado."}, status=status.HTTP_403_FORBIDDEN)
+        return Response(
+            {"detail": "Acceso denegado."}, status=status.HTTP_403_FORBIDDEN
+        )
 
     try:
         coach_profile = CoachProfile.objects.get(user=request.user)
     except CoachProfile.DoesNotExist:
         return Response(
-            {"detail": "Perfil de entrenador no encontrado."}, status=status.HTTP_404_NOT_FOUND
+            {"detail": "Perfil de entrenador no encontrado."},
+            status=status.HTTP_404_NOT_FOUND,
         )
 
     if request.method == "GET":
@@ -123,12 +126,16 @@ def CoachAthleteManagementView(request, athlete_id=None):
                 {"detail": "Atleta vinculado correctamente."}, status=status.HTTP_200_OK
             )
         except User.DoesNotExist:
-            return Response({"detail": "Atleta no encontrado."}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "Atleta no encontrado."}, status=status.HTTP_404_NOT_FOUND
+            )
 
     if request.method == "DELETE":
         # Desvincular atleta
         coach_profile.athletes.remove(athlete_id)
-        return Response({"detail": "Atleta desvinculado."}, status=status.HTTP_204_NO_CONTENT)
+        return Response(
+            {"detail": "Atleta desvinculado."}, status=status.HTTP_204_NO_CONTENT
+        )
 
 
 @api_view(["GET", "PATCH"])
@@ -156,7 +163,9 @@ def ProfileSettingsView(request):
                 if latest_weight:
                     profile_data["weight"] = latest_weight.weight
 
-                active_goal = athlete.goals.filter(is_active=True).order_by("-id").first()
+                active_goal = (
+                    athlete.goals.filter(is_active=True).order_by("-id").first()
+                )
                 if active_goal:
                     profile_data["training_goal"] = active_goal.goal_type
             except AthleteProfile.DoesNotExist:
@@ -237,7 +246,9 @@ def AthleteDashboardView(request):
     try:
         profile = AthleteProfile.objects.get(user=request.user)
     except AthleteProfile.DoesNotExist:
-        return Response({"detail": "Perfil no encontrado."}, status=status.HTTP_404_NOT_FOUND)
+        return Response(
+            {"detail": "Perfil no encontrado."}, status=status.HTTP_404_NOT_FOUND
+        )
 
     latest_weight = WeightLog.objects.filter(athlete=profile).order_by("-date").first()
     active_goal = Goal.objects.filter(athlete=profile, is_active=True).first()
@@ -248,7 +259,9 @@ def AthleteDashboardView(request):
             "age": profile.age,
             "gender": profile.gender,
             "activity_level": profile.activity_level,
-            "latest_weight": WeightLogSerializer(latest_weight).data if latest_weight else None,
+            "latest_weight": (
+                WeightLogSerializer(latest_weight).data if latest_weight else None
+            ),
             "goal": GoalSerializer(active_goal).data if active_goal else None,
         }
     )
@@ -261,7 +274,9 @@ def WeightLogView(request):
     try:
         profile = AthleteProfile.objects.get(user=request.user)
     except AthleteProfile.DoesNotExist:
-        return Response({"detail": "Perfil no encontrado."}, status=status.HTTP_404_NOT_FOUND)
+        return Response(
+            {"detail": "Perfil no encontrado."}, status=status.HTTP_404_NOT_FOUND
+        )
 
     if request.method == "GET":
         logs = WeightLog.objects.filter(athlete=profile).order_by("-date")
@@ -276,6 +291,63 @@ def WeightLogView(request):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
+@api_view(["GET", "POST"])
+@permission_classes([IsAuthenticated])
+def GoalLogView(request):
+    """Lista las metas de los atletas o agrega uno nuevo"""
+    try:
+        profile = AthleteProfile.objects.get(user=request.user)
+    except AthleteProfile.DoesNotExist:
+        return Response(
+            {"detail": "Perfil no encontrado."}, status=status.HTTP_404_NOT_FOUND
+        )
+
+    if request.method == "GET":
+        logs = Goal.objects.filter(athlete=profile).order_by("-start_date")
+        serializer = GoalSerializer(logs, many=True)
+        return Response(serializer.data)
+
+    elif request.method == "POST":
+        serializer = GoalSerializer(data=request.data)
+        if serializer.is_valid():
+            serializer.save(athlete=profile)
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+@api_view(["GET", "PUT", "DELETE"])
+@permission_classes([IsAuthenticated])
+def GoalDetailView(request, goal_id):
+    """Obtiene, edita o elimina una meta específica."""
+    try:
+        profile = AthleteProfile.objects.get(user=request.user)
+    except AthleteProfile.DoesNotExist:
+        return Response(
+            {"detail": "Perfil no encontrado."}, status=status.HTTP_404_NOT_FOUND
+        )
+
+    try:
+        goal = Goal.objects.get(id=goal_id, athlete=profile)
+    except Goal.DoesNotExist:
+        return Response(
+            {"detail": "Meta no encontrada."}, status=status.HTTP_404_NOT_FOUND
+        )
+
+    if request.method == "GET":
+        return Response(GoalSerializer(goal).data)
+
+    elif request.method == "PUT":
+        serializer = GoalSerializer(goal, data=request.data, partial=True)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    elif request.method == "DELETE":
+        goal.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
 # ── Dashboard Coach ───────────────────────────────────────────────────────────
 
 
@@ -284,12 +356,16 @@ def WeightLogView(request):
 def CoachDashboardView(request):
     """Devuelve los datos del dashboard del coach autenticado."""
     if request.user.role != "coach":
-        return Response({"detail": "Acceso denegado."}, status=status.HTTP_403_FORBIDDEN)
+        return Response(
+            {"detail": "Acceso denegado."}, status=status.HTTP_403_FORBIDDEN
+        )
 
     try:
         profile = CoachProfile.objects.get(user=request.user)
     except CoachProfile.DoesNotExist:
-        return Response({"detail": "Perfil no encontrado."}, status=status.HTTP_404_NOT_FOUND)
+        return Response(
+            {"detail": "Perfil no encontrado."}, status=status.HTTP_404_NOT_FOUND
+        )
 
     from routines.models import TrainingGroup
 

--- a/frontend/lib/repositories/dashboard/dashboard_repository.dart
+++ b/frontend/lib/repositories/dashboard/dashboard_repository.dart
@@ -37,4 +37,56 @@ class DashboardRepository {
       throw Exception('Error creando grupo');
     }
   }
+
+  Future<List<GoalModel>> getGoals() async {
+    final response = await _dio.get('athlete/goals/');
+    return (response.data as List).map((g) => GoalModel.fromJson(g)).toList();
+  }
+
+  Future<GoalModel> createGoal({
+    required String goalType,
+    String? description,
+    double? targetValue,
+    double? currentValue,
+    String? deadline,
+  }) async {
+    final response = await _dio.post(
+      'athlete/goals/',
+      data: {
+        'goal_type': goalType,
+        'description': description ?? '',
+        'target_value': targetValue,
+        'current_value': currentValue,
+        'deadline': deadline,
+      },
+    );
+    return GoalModel.fromJson(response.data);
+  }
+
+  Future<GoalModel> updateGoal(
+    int id, {
+    String? goalType,
+    String? description,
+    double? targetValue,
+    double? currentValue,
+    String? deadline,
+    bool? isActive,
+  }) async {
+    final response = await _dio.put(
+      'athlete/goals/$id/',
+      data: {
+        if (goalType != null) 'goal_type': goalType,
+        if (description != null) 'description': description,
+        if (targetValue != null) 'target_value': targetValue,
+        if (currentValue != null) 'current_value': currentValue,
+        if (deadline != null) 'deadline': deadline,
+        if (isActive != null) 'is_active': isActive,
+      },
+    );
+    return GoalModel.fromJson(response.data);
+  }
+
+  Future<void> deleteGoal(int id) async {
+    await _dio.delete('athlete/goals/$id/');
+  }
 }

--- a/frontend/lib/repositories/dashboard/dashboard_repository.dart
+++ b/frontend/lib/repositories/dashboard/dashboard_repository.dart
@@ -75,12 +75,12 @@ class DashboardRepository {
     final response = await _dio.put(
       'athlete/goals/$id/',
       data: {
-        if (goalType != null) 'goal_type': goalType,
-        if (description != null) 'description': description,
-        if (targetValue != null) 'target_value': targetValue,
-        if (currentValue != null) 'current_value': currentValue,
-        if (deadline != null) 'deadline': deadline,
-        if (isActive != null) 'is_active': isActive,
+        'goal_type': goalType,
+        'description': description,
+        'target_value': targetValue,
+        'current_value': currentValue,
+        'deadline': deadline,
+        'is_active': isActive,
       },
     );
     return GoalModel.fromJson(response.data);

--- a/frontend/lib/view_models/dashboard/dashboard_view_model.dart
+++ b/frontend/lib/view_models/dashboard/dashboard_view_model.dart
@@ -7,9 +7,10 @@ class DashboardViewModel {
   AthleteDashboardModel? athleteDashboard;
   CoachDashboardModel? coachDashboard;
   List<WeightLogModel> weightLogs = [];
-
   bool isLoading = false;
   String? errorMessage;
+
+  DashboardRepository get repository => _repository;
 
   Future<void> loadAthleteDashboard() async {
     isLoading = true;

--- a/frontend/lib/views/profile/profile_screen.dart
+++ b/frontend/lib/views/profile/profile_screen.dart
@@ -25,7 +25,6 @@ class _ProfileScreenState extends State<ProfileScreen> {
   int? _age;
   double? _weight;
   double? _height;
-  String? _trainingGoal;
 
   final ProfileRepository _profileRepository = ProfileRepository();
   final DashboardViewModel _vm = DashboardViewModel();
@@ -63,7 +62,6 @@ class _ProfileScreenState extends State<ProfileScreen> {
         _age = profile.age;
         _weight = profile.weight;
         _height = profile.height;
-        _trainingGoal = profile.trainingGoal;
         _nameCtrl.text = profile.name;
         _weightCtrl.text = profile.weight?.toStringAsFixed(1) ?? '';
         _heightCtrl.text = profile.height?.toStringAsFixed(1) ?? '';
@@ -125,7 +123,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
         _age = updated.age;
         _weight = updated.weight;
         _height = updated.height;
-        _trainingGoal = updated.trainingGoal;
+        _selectedGoal = updated.trainingGoal;
         _nameCtrl.text = updated.name;
         _weightCtrl.text = updated.weight?.toStringAsFixed(1) ?? '';
         _heightCtrl.text = updated.height?.toStringAsFixed(1) ?? '';
@@ -1198,10 +1196,11 @@ class _GoalFormDialogState extends State<_GoalFormDialog> {
       if (mounted) Navigator.pop(context);
     } catch (e) {
       debugPrint('ERROR guardando meta: $e');
-      if (mounted)
+      if (mounted) {
         ScaffoldMessenger.of(
           context,
         ).showSnackBar(const SnackBar(content: Text('Error al guardar meta')));
+      }
     } finally {
       if (mounted) setState(() => _isSaving = false);
     }
@@ -1271,7 +1270,7 @@ class _GoalFormDialogState extends State<_GoalFormDialog> {
             ),
             const SizedBox(height: 16),
             DropdownButtonFormField<String>(
-              value: _selectedGoalType,
+              initialValue: _selectedGoalType,
               decoration: _inputDec(
                 'Tipo de objetivo',
                 icon: Icons.flag_rounded,

--- a/frontend/lib/views/profile/profile_screen.dart
+++ b/frontend/lib/views/profile/profile_screen.dart
@@ -2,6 +2,8 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import '../../core/token_storage.dart';
 import '../../models/profile/profile_settings_model.dart';
+import '../../models/dashboard/dashboard_model.dart';
+import '../../repositories/dashboard/dashboard_repository.dart';
 import '../../repositories/profile/profile_repository.dart';
 import '../../theme/app_colors.dart';
 import '../../theme/app_radius.dart';
@@ -68,7 +70,6 @@ class _ProfileScreenState extends State<ProfileScreen> {
         _selectedGoal = profile.trainingGoal;
         _isProfileLoading = false;
       });
-      // Cargar datos del dashboard según el rol
       if (_role == 'athlete') {
         await _vm.loadAthleteDashboard();
       } else if (_role == 'coach') {
@@ -144,6 +145,19 @@ class _ProfileScreenState extends State<ProfileScreen> {
     ScaffoldMessenger.of(
       context,
     ).showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  void _openGoalsDialog() {
+    showDialog(
+      context: context,
+      builder: (_) => _GoalsDialog(
+        repository: _vm.repository,
+        onChanged: () async {
+          await _vm.loadAthleteDashboard();
+          if (mounted) setState(() {});
+        },
+      ),
+    );
   }
 
   void _openSettingsSheet() {
@@ -404,7 +418,6 @@ class _ProfileScreenState extends State<ProfileScreen> {
             : SingleChildScrollView(
                 child: Column(
                   children: [
-                    // Header
                     Container(
                       width: double.infinity,
                       padding: const EdgeInsets.only(
@@ -461,21 +474,15 @@ class _ProfileScreenState extends State<ProfileScreen> {
                         ],
                       ),
                     ),
-
                     const SizedBox(height: 24),
-
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 24),
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          // Datos por rol
                           if (_role == 'athlete') _buildAthleteProfile(),
                           if (_role == 'coach') _buildCoachProfile(),
-
                           const SizedBox(height: 24),
-
-                          // Configuración
                           Text(
                             'Configuracion',
                             style: AppTextStyles.fitnessBold.copyWith(
@@ -563,11 +570,115 @@ class _ProfileScreenState extends State<ProfileScreen> {
             ),
           ],
         ),
+        const SizedBox(height: 24),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              'Mi objetivo',
+              style: AppTextStyles.fitnessBold.copyWith(
+                color: AppColors.textPrimary,
+              ),
+            ),
+            GestureDetector(
+              onTap: _openGoalsDialog,
+              child: Text(
+                'Ver metas',
+                style: TextStyle(
+                  color: AppColors.primary,
+                  fontWeight: FontWeight.w600,
+                  fontSize: 13,
+                ),
+              ),
+            ),
+          ],
+        ),
         const SizedBox(height: 12),
-        _ProfileStatCard(
-          label: 'Objetivo',
-          value: _goalLabel(_trainingGoal),
-          icon: Icons.flag_rounded,
+        GestureDetector(
+          onTap: _openGoalsDialog,
+          child: Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: AppColors.surface,
+              borderRadius: AppRadius.card,
+              boxShadow: AppColors.softShadow,
+            ),
+            child: d?.goal == null
+                ? Row(
+                    children: [
+                      Icon(
+                        Icons.flag_rounded,
+                        color: AppColors.primary,
+                        size: 20,
+                      ),
+                      const SizedBox(width: 14),
+                      const Expanded(
+                        child: Text(
+                          'Sin objetivo activo',
+                          style: TextStyle(
+                            fontSize: 15,
+                            fontWeight: FontWeight.w600,
+                            color: AppColors.textPrimary,
+                          ),
+                        ),
+                      ),
+                      const Icon(
+                        Icons.chevron_right,
+                        color: AppColors.textSecondary,
+                      ),
+                    ],
+                  )
+                : Row(
+                    children: [
+                      Icon(
+                        Icons.flag_rounded,
+                        color: AppColors.primary,
+                        size: 20,
+                      ),
+                      const SizedBox(width: 14),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              _goalLabel(d!.goal!.goalType),
+                              style: const TextStyle(
+                                fontSize: 15,
+                                fontWeight: FontWeight.w700,
+                                color: AppColors.textPrimary,
+                              ),
+                            ),
+                            if (d.goal!.targetValue != null) ...[
+                              const SizedBox(height: 2),
+                              Text(
+                                'Objetivo: ${d.goal!.targetValue}',
+                                style: const TextStyle(
+                                  fontSize: 12,
+                                  color: AppColors.textSecondary,
+                                ),
+                              ),
+                            ],
+                            if (d.goal!.deadline != null) ...[
+                              const SizedBox(height: 2),
+                              Text(
+                                'Fecha límite: ${d.goal!.deadline}',
+                                style: const TextStyle(
+                                  fontSize: 11,
+                                  color: AppColors.textSecondary,
+                                ),
+                              ),
+                            ],
+                          ],
+                        ),
+                      ),
+                      const Icon(
+                        Icons.chevron_right,
+                        color: AppColors.textSecondary,
+                      ),
+                    ],
+                  ),
+          ),
         ),
         const SizedBox(height: 12),
         _buildOption(
@@ -575,13 +686,14 @@ class _ProfileScreenState extends State<ProfileScreen> {
           label: d?.latestWeight != null
               ? 'Peso reciente: ${d!.latestWeight!.weight} kg — ${d.latestWeight!.date}'
               : 'Ver historial de peso',
-          onTap: () {}, // navegar a historial de peso
+          onTap: () {},
         ),
       ],
     );
   }
 
   // ── Perfil Coach ───────────────────────────────────────────────────────────
+
   Widget _buildCoachProfile() {
     final d = _vm.coachDashboard;
     return Column(
@@ -726,8 +838,6 @@ class _ProfileScreenState extends State<ProfileScreen> {
     );
   }
 
-  // ── Mapeos ─────────────────────────────────────────────────────────────────
-
   String _mapActivity(String level) {
     switch (level) {
       case 'high':
@@ -799,6 +909,479 @@ class _ProfileStatCard extends StatelessWidget {
     );
   }
 }
+
+// ── Goals Dialog ───────────────────────────────────────────────────────────
+
+class _GoalsDialog extends StatefulWidget {
+  final DashboardRepository repository;
+  final VoidCallback onChanged;
+
+  const _GoalsDialog({required this.repository, required this.onChanged});
+
+  @override
+  State<_GoalsDialog> createState() => _GoalsDialogState();
+}
+
+class _GoalsDialogState extends State<_GoalsDialog> {
+  List<GoalModel> _goals = [];
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadGoals();
+  }
+
+  Future<void> _loadGoals() async {
+    setState(() => _isLoading = true);
+    try {
+      final data = await widget.repository.getGoals();
+      if (mounted) setState(() => _goals = data);
+    } catch (e) {
+      debugPrint('ERROR cargando metas: $e');
+    } finally {
+      if (mounted) setState(() => _isLoading = false);
+    }
+  }
+
+  void _openForm({GoalModel? goal}) {
+    showDialog(
+      context: context,
+      builder: (_) => _GoalFormDialog(
+        repository: widget.repository,
+        goal: goal,
+        onSaved: () {
+          _loadGoals();
+          widget.onChanged();
+        },
+      ),
+    );
+  }
+
+  Future<void> _deleteGoal(GoalModel goal) async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Eliminar meta'),
+        content: Text('¿Eliminar "${_goalLabel(goal.goalType)}"?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancelar'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(context, true),
+            style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
+            child: const Text(
+              'Eliminar',
+              style: TextStyle(color: Colors.white),
+            ),
+          ),
+        ],
+      ),
+    );
+    if (confirm == true) {
+      await widget.repository.deleteGoal(goal.id);
+      _loadGoals();
+      widget.onChanged();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      insetPadding: const EdgeInsets.symmetric(horizontal: 24, vertical: 40),
+      child: SizedBox(
+        width: double.infinity,
+        height: 520,
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 20, 12, 0),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      'Mis metas',
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close),
+                    onPressed: () => Navigator.pop(context),
+                  ),
+                ],
+              ),
+            ),
+            const Divider(),
+            Expanded(
+              child: _isLoading
+                  ? const Center(
+                      child: CircularProgressIndicator(
+                        color: AppColors.primary,
+                      ),
+                    )
+                  : _goals.isEmpty
+                  ? const Center(child: Text('Sin metas registradas'))
+                  : ListView.builder(
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      itemCount: _goals.length,
+                      itemBuilder: (context, index) {
+                        final goal = _goals[index];
+                        return Container(
+                          margin: const EdgeInsets.only(bottom: 10),
+                          padding: const EdgeInsets.all(14),
+                          decoration: BoxDecoration(
+                            color: AppColors.primary.withValues(alpha: 0.07),
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: Row(
+                            children: [
+                              Container(
+                                padding: const EdgeInsets.all(7),
+                                decoration: BoxDecoration(
+                                  color: AppColors.primary.withValues(
+                                    alpha: 0.15,
+                                  ),
+                                  borderRadius: BorderRadius.circular(8),
+                                ),
+                                child: const Icon(
+                                  Icons.flag_rounded,
+                                  color: AppColors.primary,
+                                  size: 18,
+                                ),
+                              ),
+                              const SizedBox(width: 12),
+                              Expanded(
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text(
+                                      _goalLabel(goal.goalType),
+                                      style: const TextStyle(
+                                        fontWeight: FontWeight.w700,
+                                        fontSize: 14,
+                                        color: AppColors.textPrimary,
+                                      ),
+                                    ),
+                                    if (goal.targetValue != null)
+                                      Text(
+                                        'Objetivo: ${goal.targetValue}',
+                                        style: const TextStyle(
+                                          fontSize: 12,
+                                          color: AppColors.textSecondary,
+                                        ),
+                                      ),
+                                    if (goal.deadline != null)
+                                      Text(
+                                        'Fecha límite: ${goal.deadline}',
+                                        style: const TextStyle(
+                                          fontSize: 11,
+                                          color: AppColors.textSecondary,
+                                        ),
+                                      ),
+                                  ],
+                                ),
+                              ),
+                              IconButton(
+                                icon: const Icon(
+                                  Icons.edit_outlined,
+                                  color: AppColors.primary,
+                                  size: 20,
+                                ),
+                                onPressed: () => _openForm(goal: goal),
+                              ),
+                              IconButton(
+                                icon: const Icon(
+                                  Icons.delete_outline,
+                                  color: Colors.red,
+                                  size: 20,
+                                ),
+                                onPressed: () => _deleteGoal(goal),
+                              ),
+                            ],
+                          ),
+                        );
+                      },
+                    ),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: SizedBox(
+                width: double.infinity,
+                child: FilledButton.icon(
+                  onPressed: () => _openForm(),
+                  style: FilledButton.styleFrom(
+                    backgroundColor: AppColors.primary,
+                  ),
+                  icon: const Icon(Icons.add),
+                  label: const Text('Nueva meta'),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Goal Form Dialog ───────────────────────────────────────────────────────
+
+class _GoalFormDialog extends StatefulWidget {
+  final DashboardRepository repository;
+  final GoalModel? goal;
+  final VoidCallback onSaved;
+
+  const _GoalFormDialog({
+    required this.repository,
+    this.goal,
+    required this.onSaved,
+  });
+
+  @override
+  State<_GoalFormDialog> createState() => _GoalFormDialogState();
+}
+
+class _GoalFormDialogState extends State<_GoalFormDialog> {
+  final _targetCtrl = TextEditingController();
+  final _currentCtrl = TextEditingController();
+  final _descCtrl = TextEditingController();
+  String? _selectedGoalType;
+  String? _selectedDeadline;
+  bool _isSaving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.goal != null) {
+      final g = widget.goal!;
+      _selectedGoalType = g.goalType;
+      _targetCtrl.text = g.targetValue?.toString() ?? '';
+      _currentCtrl.text = g.currentValue?.toString() ?? '';
+      _descCtrl.text = g.description;
+      _selectedDeadline = g.deadline;
+    }
+  }
+
+  @override
+  void dispose() {
+    _targetCtrl.dispose();
+    _currentCtrl.dispose();
+    _descCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    if (_selectedGoalType == null) return;
+    setState(() => _isSaving = true);
+    try {
+      if (widget.goal == null) {
+        await widget.repository.createGoal(
+          goalType: _selectedGoalType!,
+          description: _descCtrl.text.trim(),
+          targetValue: double.tryParse(_targetCtrl.text),
+          currentValue: double.tryParse(_currentCtrl.text),
+          deadline: _selectedDeadline,
+        );
+      } else {
+        await widget.repository.updateGoal(
+          widget.goal!.id,
+          goalType: _selectedGoalType,
+          description: _descCtrl.text.trim(),
+          targetValue: double.tryParse(_targetCtrl.text),
+          currentValue: double.tryParse(_currentCtrl.text),
+          deadline: _selectedDeadline,
+        );
+      }
+      widget.onSaved();
+      if (mounted) Navigator.pop(context);
+    } catch (e) {
+      debugPrint('ERROR guardando meta: $e');
+      if (mounted)
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('Error al guardar meta')));
+    } finally {
+      if (mounted) setState(() => _isSaving = false);
+    }
+  }
+
+  Future<void> _pickDeadline() async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: DateTime.now().add(const Duration(days: 30)),
+      firstDate: DateTime.now(),
+      lastDate: DateTime(2030),
+      builder: (context, child) => Theme(
+        data: Theme.of(context).copyWith(
+          colorScheme: const ColorScheme.light(primary: AppColors.primary),
+        ),
+        child: child!,
+      ),
+    );
+    if (picked != null) {
+      setState(() {
+        _selectedDeadline =
+            '${picked.year}-${picked.month.toString().padLeft(2, '0')}-${picked.day.toString().padLeft(2, '0')}';
+      });
+    }
+  }
+
+  InputDecoration _inputDec(String label, {IconData? icon}) {
+    return InputDecoration(
+      labelText: label,
+      labelStyle: const TextStyle(color: AppColors.primary),
+      prefixIcon: icon != null ? Icon(icon, color: AppColors.primary) : null,
+      filled: true,
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: BorderSide.none,
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: const BorderSide(color: AppColors.primary, width: 1.5),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      insetPadding: const EdgeInsets.symmetric(horizontal: 24, vertical: 40),
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    widget.goal == null ? 'Nueva meta' : 'Editar meta',
+                    style: Theme.of(context).textTheme.titleLarge,
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.close),
+                  onPressed: () => Navigator.pop(context),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            DropdownButtonFormField<String>(
+              value: _selectedGoalType,
+              decoration: _inputDec(
+                'Tipo de objetivo',
+                icon: Icons.flag_rounded,
+              ),
+              items: _goalOptions
+                  .map(
+                    (g) =>
+                        DropdownMenuItem(value: g.value, child: Text(g.label)),
+                  )
+                  .toList(),
+              onChanged: (v) => setState(() => _selectedGoalType = v),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _targetCtrl,
+              keyboardType: const TextInputType.numberWithOptions(
+                decimal: true,
+              ),
+              decoration: _inputDec(
+                'Valor objetivo (ej: 70 kg)',
+                icon: Icons.track_changes,
+              ),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _currentCtrl,
+              keyboardType: const TextInputType.numberWithOptions(
+                decimal: true,
+              ),
+              decoration: _inputDec('Valor actual', icon: Icons.trending_up),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _descCtrl,
+              decoration: _inputDec(
+                'Descripción (opcional)',
+                icon: Icons.notes,
+              ),
+            ),
+            const SizedBox(height: 12),
+            GestureDetector(
+              onTap: _pickDeadline,
+              child: Container(
+                width: double.infinity,
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 14,
+                  vertical: 14,
+                ),
+                decoration: BoxDecoration(
+                  color: AppColors.background,
+                  borderRadius: BorderRadius.circular(12),
+                  border: Border.all(
+                    color: _selectedDeadline != null
+                        ? AppColors.primary
+                        : Colors.transparent,
+                  ),
+                ),
+                child: Row(
+                  children: [
+                    const Icon(
+                      Icons.calendar_today,
+                      color: AppColors.primary,
+                      size: 18,
+                    ),
+                    const SizedBox(width: 10),
+                    Text(
+                      _selectedDeadline ?? 'Seleccionar fecha límite',
+                      style: TextStyle(
+                        color: _selectedDeadline != null
+                            ? AppColors.textPrimary
+                            : AppColors.textSecondary,
+                        fontSize: 14,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 20),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: _isSaving || _selectedGoalType == null
+                    ? null
+                    : _save,
+                style: FilledButton.styleFrom(
+                  backgroundColor: AppColors.primary,
+                ),
+                child: _isSaving
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: Colors.white,
+                        ),
+                      )
+                    : Text(
+                        widget.goal == null ? 'Crear meta' : 'Guardar cambios',
+                      ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
 
 String _goalLabel(String? goal) {
   switch (goal) {


### PR DESCRIPTION
Implementa el flujo completo para que el atleta pueda registrar y gestionar sus objetivos personales con fecha límite y valores esperados. Incluye endpoints REST con validación de permisos y una sección en el perfil que muestra la meta activa con opción de gestionar todas las metas desde un popup